### PR TITLE
Bruk riktig lenke til klageskjema

### DIFF
--- a/components/NyttigÅVite/NyttigÅVite.tsx
+++ b/components/NyttigÅVite/NyttigÅVite.tsx
@@ -47,7 +47,7 @@ export const NyttigÅVite = () => {
             id="hvaSkjerPanel.punkt2.tekst"
             values={{
               a: (chunks) => (
-                <Link target="_blank" href="https://klage.nav.no/nb/klage/ny/NAV_LOVEN_14A">
+                <Link target="_blank" href="https://klage.nav.no/nb/klage/nav_loven_14a">
                   {chunks}
                 </Link>
               ),


### PR DESCRIPTION
Hei!
`ny`-pathen har vært deprecated en stund, og er nå ikke lenger støttet i det hele tatt, noe som bare fører til at bruker blir redirectet til https://www.nav.no/klage. I tillegg støtter vi nå så bokstaver i ytelsenavnet. :)